### PR TITLE
Fee token check

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,19 @@ interest will accumulate to the wrapper token.
 
 ### Fee tokens
 
-Additionally, the EncumberableTokenFactory does not support fee tokens.
+The EncumberableTokenFactory does not work for fee tokens.
 
-The `doTransferIn` and `doTransferOut` functions assume that a succesful call of
+If a token does not transfer the full amount requested during a `transfer` call
+(by having a fee on transfer, for example), then it is possible that a user
+would be able to drain the wrapper contract's balance of the underlying token by
+minting a greater amount of the wrapper token than they have actually
+transferred in, and then burning that greater amount for more of the underlying
+token than they transferred in.
+
+The `doTransferIn` function confirms that a successful call to
 `ERC2(token).transferFrom(src, dst, amount)` will result in `amount` tokens
-being transferred to `dst`. Those functions do not verify the amount that has
-been transferred.
-
-If a token breaks this assumption (by having a fee on transfer, for example),
-then it is possible that a user would be able to drain the wrapper contract's
-balance of the underlying token by minting a greater amount of the wrapper token
-than they have actually transferred in, and then burning that greater amount for
-more of the underlying token than they transferred in.
+being transferred to `dst`; if not, the call will revert. This should prevent
+minting a wrapped token whose underlying token takes a fee on transfer.
 
 # Deployed addresses
 

--- a/src/EncumberableToken.sol
+++ b/src/EncumberableToken.sol
@@ -341,10 +341,12 @@ contract EncumberableToken is ERC20, IERC20Permit, IERC7246 {
      * @param asset The ERC-20 token to transfer in
      * @param from The address to transfer from
      * @param amount The amount of the token to transfer
-     * @dev Note: This does not check that the amount transferred in is actually equals to the amount specified (e.g. fee tokens will not revert)
+     * @dev Note: This function checks that the amount transferred in equals the amount specified (e.g. fee tokens will revert)
      * @dev Note: This wrapper safely handles non-standard ERC-20 tokens that do not return a value. See here: https://medium.com/coinmonks/missing-return-value-bug-at-least-130-tokens-affected-d67bf08521ca
      */
     function doTransferIn(address asset, address from, uint256 amount) internal {
+        uint256 preTransferBalance = ERC20(asset).balanceOf(address(this));
+
         IERC20NonStandard(asset).transferFrom(from, address(this), amount);
 
         bool success;
@@ -362,6 +364,9 @@ contract EncumberableToken is ERC20, IERC20Permit, IERC7246 {
                 }
         }
         require(success, "Transfer in failed");
+
+        uint256 postTransferBalance = ERC20(asset).balanceOf(address(this));
+        require(postTransferBalance == preTransferBalance + amount, "ERC7246: Insufficient amount transferred in");
     }
 
     /**

--- a/src/test/FeeToken.sol
+++ b/src/test/FeeToken.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.20;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract FeeToken is ERC20 {
+    uint256 constant TRANSFER_FEE = 1e18;
+
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function transfer(address to, uint256 amount) public virtual override returns (bool) {
+        _transfer(msg.sender, to, amount - TRANSFER_FEE);
+        _transfer(msg.sender, address(this), TRANSFER_FEE);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public virtual override returns (bool) {
+        _spendAllowance(from, msg.sender, amount);
+        _transfer(from, to, amount - TRANSFER_FEE);
+        _transfer(from, address(this), TRANSFER_FEE);
+        return true;
+    }
+}

--- a/test/FeeToken.t.sol
+++ b/test/FeeToken.t.sol
@@ -1,0 +1,46 @@
+pragma solidity ^0.8.20;
+
+import "forge-std/StdUtils.sol";
+import { Test } from "forge-std/Test.sol";
+import { EncumberableToken } from "../src/EncumberableToken.sol";
+import { FeeToken } from "../src/test/FeeToken.sol";
+
+contract FeeTokenTest is Test {
+    FeeToken public feeToken;
+    EncumberableToken public wrappedToken;
+
+    address alice = address(10);
+    address bob = address(11);
+    address charlie = address(12);
+
+    function setUp() public {
+        feeToken = new FeeToken("Fee Token", "FEETO");
+        wrappedToken = new EncumberableToken(address(feeToken));
+    }
+
+    function testFeeOnTransfer() public {
+        deal(address(feeToken), alice, 100e18);
+
+        vm.prank(alice);
+        feeToken.transfer(bob, 100e18);
+
+        assertEq(feeToken.balanceOf(alice), 0);
+        assertEq(feeToken.balanceOf(bob), 99e18);
+        assertEq(feeToken.balanceOf(address(feeToken)), 1e18);
+    }
+
+    function testFeeOnTransferFrom() public {
+        deal(address(feeToken), alice, 100e18);
+
+        vm.prank(alice);
+        feeToken.approve(bob, 100e18);
+
+        vm.prank(bob);
+        feeToken.transferFrom(alice, charlie, 100e18);
+
+        assertEq(feeToken.balanceOf(alice), 0);
+        assertEq(feeToken.balanceOf(bob), 0);
+        assertEq(feeToken.balanceOf(charlie), 99e18);
+        assertEq(feeToken.balanceOf(address(feeToken)), 1e18);
+    }
+}

--- a/test/FeeToken.t.sol
+++ b/test/FeeToken.t.sol
@@ -43,4 +43,16 @@ contract FeeTokenTest is Test {
         assertEq(feeToken.balanceOf(charlie), 99e18);
         assertEq(feeToken.balanceOf(address(feeToken)), 1e18);
     }
+
+    function testRevertOnTransferInWithFee() public {
+        deal(address(feeToken), alice, 100e18);
+
+        vm.startPrank(alice);
+        feeToken.approve(address(wrappedToken), 100e18);
+
+        vm.expectRevert("ERC7246: Insufficient amount transferred in");
+        wrappedToken.wrap(alice, 100e18);
+
+        vm.stopPrank();
+    }
 }


### PR DESCRIPTION
More OZ feedback:

> L-02 Fee-Charging Tokens Are Allowed

Per OZ's suggestion, adding a check to the `doTransferIn` function that reverts if the amount transferred in does not equal the amount requested.

This means that even if someone created a wrapper for a fee token, users will be unable to mint the wrapped token.