### PR TITLE
revert in release() for excess amount

### DIFF
--- a/src/EncumberableToken.sol
+++ b/src/EncumberableToken.sol
@@ -183,9 +183,7 @@ contract EncumberableToken is ERC20, IERC20Permit, IERC7246 {
      * @dev Reduce `owner`'s encumbrance to `taker` by `amount`
      */
     function _release(address owner, address taker, uint256 amount) private {
-        if (encumbrances[owner][taker] < amount) {
-          amount = encumbrances[owner][taker];
-        }
+        require(encumbrances[owner][taker] >= amount, "ERC7246: insufficient encumbrance");
         encumbrances[owner][taker] -= amount;
         encumberedBalanceOf[owner] -= amount;
         emit Release(owner, taker, amount);

--- a/test/EncumberableToken.t.sol
+++ b/test/EncumberableToken.t.sol
@@ -270,7 +270,7 @@ contract EncumberableTokenTest is Test {
 
         vm.prank(alice);
 
-        // alice encumbers some of her balance to bob
+        // alice encumbers her balance to bob
         wrappedToken.encumber(bob, 100e18);
 
         assertEq(wrappedToken.balanceOf(alice), 100e18);
@@ -289,6 +289,30 @@ contract EncumberableTokenTest is Test {
         assertEq(wrappedToken.availableBalanceOf(alice), 40e18);
         assertEq(wrappedToken.encumberedBalanceOf(alice), 60e18);
         assertEq(wrappedToken.encumbrances(alice, bob), 60e18);
+    }
+
+    function testReleaseInsufficientEncumbrance() public {
+        deal(address(wrappedToken), alice, 100e18);
+
+        vm.prank(alice);
+
+        // alice encumbers her balance to bob
+        wrappedToken.encumber(bob, 100e18);
+
+        assertEq(wrappedToken.balanceOf(alice), 100e18);
+        assertEq(wrappedToken.availableBalanceOf(alice), 0);
+        assertEq(wrappedToken.encumberedBalanceOf(alice), 100e18);
+        assertEq(wrappedToken.encumbrances(alice, bob), 100e18);
+
+        // bob releases a greater amount than is encumbered to him
+        vm.prank(bob);
+        vm.expectRevert("ERC7246: insufficient encumbrance");
+        wrappedToken.release(alice, 200e18);
+
+        assertEq(wrappedToken.balanceOf(alice), 100e18);
+        assertEq(wrappedToken.availableBalanceOf(alice), 0);
+        assertEq(wrappedToken.encumberedBalanceOf(alice), 100e18);
+        assertEq(wrappedToken.encumbrances(alice, bob), 100e18);
     }
 
     function testWrap() public {


### PR DESCRIPTION
⛑️ pointed out that it might be more in line with ERC20 to revert for an excess amount requested for release.