### PR TITLE
create EncumbranceUpdate event

### DIFF
--- a/src/interfaces/IERC7246.sol
+++ b/src/interfaces/IERC7246.sol
@@ -7,15 +7,10 @@ pragma solidity ^0.8.20;
  */
 interface IERC7246 {
     /**
-     * @dev Emitted when `amount` tokens are encumbered from `owner` to `taker`.
+     * @dev Emitted when the encumbrance of a `taker` to an `owner` is altered,
+     * by creating an encumbrance, spending it or releasing it
      */
-    event Encumber(address indexed owner, address indexed taker, uint256 amount);
-
-    /**
-     * @dev Emitted when the encumbrance of a `taker` to an `owner` is reduced
-     * by `amount`.
-     */
-    event Release(address indexed owner, address indexed taker, uint256 amount);
+    event EncumbranceUpdate(address indexed owner, address indexed taker, uint256 previousAmount, uint256 newAmount);
 
     /**
      * @dev Returns the total amount of tokens owned by `owner` that are


### PR DESCRIPTION
The OpenZeppelin audit of the Encumber Factory pointed out that there is no event in the EncumberableToken that is emitted when encumbrances are spent.

The IERC7246 spec defines `Encumber` events for when an encumbrance is created and `Release` events for when an encumbrance is released, but no event for when it is spent. These events include the diff between the previous value and the new value, but do not include what the current encumbrance is from the `owner` to the `taker`.

This means that it is not possible to reconstruct an account's current encumbrance state using event logs. For example:

- Alice encumbers 100 tokens to Bob; an `Encumber(alice, bob, 100e18)` event is emitted
- Bob transfers 30 tokens to Charlie; no encumber event is emitted. The Transfer events shows a transfer from Alice to Charlie
- Bob releases 20 encumbered tokens back to Alice; a `Release(alice, bob, 20e18)` event is emitted

Reading the events might give you the false impression that Alice still had 80e18 tokens encumbered to Bob; really her encumbrance balance is 50e18 (100 encumbered - (30 spent + 20 released));

This PR suggests merging the existing events into a single event that can work for encumbering, spending and releasing:

`event EncumbranceUpdate(address indexed owner, address indexed taker, uint256 previousAmount, uint256 newAmount)`

Using the previous example:

- Creating a new encumbrance would emit: `EncumbranceUpdate(alice, bob, 0, 100e18)`
- Spending would emit: `EncumbranceUpdate(alice, bob, 100e18, 70e18)`
- Releasing would emit: `EncumbranceUpdate(alice, bob, 70e18, 50e18)`

You can tell whether an encumbrance is increased or decreased by checking the diff between the two published values. You can tell whether a reduction was caused by a `release` or by a `spend` based on whether it was emitted along with a `Transfer` event. And you can always determine the current encumbrance for an `owner` to `taker` by reading the most recently-emitted event (you don't need to have the full history of events).