### PR TITLE
EncumbranceSpend event

### DIFF
--- a/src/EncumberableToken.sol
+++ b/src/EncumberableToken.sol
@@ -130,6 +130,7 @@ contract EncumberableToken is ERC20, IERC20Permit, IERC7246 {
         uint256 newEncumbrance = currentEncumbrance - amount;
         encumbrances[owner][taker] = newEncumbrance;
         encumberedBalanceOf[owner] -= amount;
+        emit EncumbranceSpend(owner, taker, amount);
     }
 
     /**

--- a/src/interfaces/IERC7246.sol
+++ b/src/interfaces/IERC7246.sol
@@ -12,10 +12,16 @@ interface IERC7246 {
     event Encumber(address indexed owner, address indexed taker, uint256 amount);
 
     /**
-     * @dev Emitted when the encumbrance of a `taker` to an `owner` is reduced
+     * @dev Emitted when the encumbrance of an `owner` to a `taker` is reduced
      * by `amount`.
      */
     event Release(address indexed owner, address indexed taker, uint256 amount);
+
+    /**
+     * @dev Emitted when `amount` of encumbrance of an `owner` to a `taker` is
+     * spent.
+     */
+    event EncumbranceSpend(address indexed owner, address indexed taker, uint256 amount);
 
     /**
      * @dev Returns the total amount of tokens owned by `owner` that are

--- a/test/EncumberableToken.t.sol
+++ b/test/EncumberableToken.t.sol
@@ -9,6 +9,7 @@ import { EncumberableToken } from "../src/EncumberableToken.sol";
 contract EncumberableTokenTest is Test {
     event Encumber(address indexed owner, address indexed taker, uint amount);
     event Release(address indexed owner, address indexed taker, uint amount);
+    event EncumbranceSpend(address indexed owner, address indexed taker, uint256 amount);
 
     ERC20 public underlyingToken;
     EncumberableToken public wrappedToken;
@@ -142,6 +143,8 @@ contract EncumberableTokenTest is Test {
 
         // bob calls transfers from alice to charlie
         vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit EncumbranceSpend(alice, bob, 40e18);
         wrappedToken.transferFrom(alice, charlie, 40e18);
 
         // alice balance is reduced
@@ -175,6 +178,8 @@ contract EncumberableTokenTest is Test {
 
         // bob calls transfers from alice to charlie
         vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit EncumbranceSpend(alice, bob, 20e18);
         wrappedToken.transferFrom(alice, charlie, 40e18);
 
         // alice balance is reduced


### PR DESCRIPTION
After some additional discussion in #22, the consensus seems to be forming that it would be preferable to have a 3rd Encumbrance event for spending an Encumbrance, and that it should match the arguments of the existing `Encumber` and `Release` functions. 