### PR TITLE
replace _spendEncumbrance with _releaseEncumbrance

### DIFF
--- a/src/interfaces/IERC7246.sol
+++ b/src/interfaces/IERC7246.sol
@@ -12,7 +12,7 @@ interface IERC7246 {
     event Encumber(address indexed owner, address indexed taker, uint256 amount);
 
     /**
-     * @dev Emitted when the encumbrance of a `taker` to an `owner` is reduced
+     * @dev Emitted when the encumbrance of an `owner` to a `taker` is reduced
      * by `amount`.
      */
     event Release(address indexed owner, address indexed taker, uint256 amount);

--- a/test/EncumberableToken.t.sol
+++ b/test/EncumberableToken.t.sol
@@ -142,6 +142,8 @@ contract EncumberableTokenTest is Test {
 
         // bob calls transfers from alice to charlie
         vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit Release(alice, bob, 40e18);
         wrappedToken.transferFrom(alice, charlie, 40e18);
 
         // alice balance is reduced
@@ -175,6 +177,8 @@ contract EncumberableTokenTest is Test {
 
         // bob calls transfers from alice to charlie
         vm.prank(bob);
+        vm.expectEmit(true, true, true, true);
+        emit Release(alice, bob, 20e18);
         wrappedToken.transferFrom(alice, charlie, 40e18);
 
         // alice balance is reduced


### PR DESCRIPTION
Now that Coburn is back from leave, revisiting the third encumbrance event.

This approach is an alternative to the `EncumbranceSpend` event from #25. Coburn has pointed out that the logic of `_release` and `_spendEncumbrance` are nearly identical.

This patch merges the two functions (renamed to `_releaseEncumbrance`). This means that when you spend an encumbrance, a `Release` event is emitted.

If you want to track an address's encumbrance, you can do so by reading `Encumber` and `Release` amounts. If you want to track their balance, you can do so by reading `Mint`, `Transfer` and `Burn` amounts.