### PR TITLE
add test for excess amount bug; patch issue

### DIFF
--- a/test/EncumberableToken.t.sol
+++ b/test/EncumberableToken.t.sol
@@ -196,7 +196,7 @@ contract EncumberableTokenTest is Test {
         assertEq(wrappedToken.balanceOf(charlie), 40e18);
     }
 
-    function testTransferFromRevertsIfYouSpendEncumberedTokens() public {
+    function testTransferFromRevertsIfSpendingTokensEncumberedToOthers() public {
         deal(address(wrappedToken), alice, 200e18);
         vm.startPrank(alice);
 


### PR DESCRIPTION
⛑️ found a vulnerability in EncumberableToken (missed by 2 audits).

In `transferFrom`, when you're spending both an encumbrance and an allowance, we do a check that ensures that the available balance for a given `src` is greater than the excess amount (the amount you're trying to transfer minus the amount that you have encumbered to you).

However, we do this check _after_ we call `_spendEncumbrance`. Spend encumbrance reduces the encumbered amount of the `src`, so the available balance at that moment is higher than it was initially.

The issue exists in the example implementation of the EIP spec as well: https://github.com/ethereum/EIPs/pull/7246/files#diff-8719190fe0e9865f0a3efbe75c597ca487bacec72fcc6ef497ea2a94bf80820eR192





